### PR TITLE
Prawn dependency too far ahead

### DIFF
--- a/prawn-print.gemspec
+++ b/prawn-print.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "prawn", "> 0.12.0"
+  s.add_dependency "prawn", "~> 0.12.0"
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "guard"


### PR DESCRIPTION
Prawn's current release is 0.12.0 so this gem fails to install with "Could not find gem 'prawn (> 0.12.0)', required by 'prawn-print', in any of the sources."

As far as I can tell, the prawn-print code seems to work fine in Prawn 0.12.0.
