### PR TITLE
Gemfile: refer to https rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in prawn-print.gemspec
 gemspec


### PR DESCRIPTION
Use HTTPS to refer to rubygems.org.